### PR TITLE
Support for listing, editing, saving and publishing text drafts

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,10 @@
+TODO
+
+* Clean up `tumble-text-draft-save'.
+   - Mostly a matter of refactoring.
+
+* Clean up `tumble-fetch-posts'
+   - HTTP GET, perhaps?
+   - How about proper handling of the status codes?
+
+* Rephrase the crap documentation strings.


### PR DESCRIPTION
Big chunk of code coming through!
I wanted to be able to edit my drafts from Emacs, so I went ahead and implemented it. This includes a major mode for listing posts and two minor modes for selecting and saving drafts, as well as a number of utility functions for accessing the read api and parsing the result.
It isn't pretty, but the functionality is there and should be (relatively) easily extendable for the other post formats.
I've included a pretty good overview of the commands, supplied pretty crappy documentation for the auxiliary functions and I have sadly not even touched the README.

Try it out, see if you like it :)
