### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/tumble.el
+++ b/tumble.el
@@ -8,6 +8,7 @@
 ;; Johan Persson <johan.z.persson@gmail.com>
 ;; Created: 1 Dec 2008
 ;; Version: 1.5
+;; Package-Requires: ((http-post-simple "0"))
 ;; Keywords: tumblr
 
 ;; This file is NOT part of GNU Emacs.


### PR DESCRIPTION
When installed as a package from an ELPA archive such as Marmalade or [MELPA](http://melpa.milkbox.net), this header tells package.el to also install http-post-simple, which the library requires.

-Steve
