### PR TITLE
Use defvar for declaring global variables

### DIFF
--- a/tumble.el
+++ b/tumble.el
@@ -106,15 +106,15 @@
 (require 'http-post-simple)
 
 ;; Personal information
-(setq tumble-email nil)
-(setq tumble-password nil)
-(setq tumble-url nil)
+(defvar tumble-email nil)
+(defvar tumble-password nil)
+(defvar tumble-url nil)
 
 ;; Optional information
-(setq tumble-group nil)                      ; uncomment to use a group.
-(setq tumble-format  "markdown")            ; you can change this to html
-(setq tumble-api-url "http://www.tumblr.com/api/write")
-(setq tumble-states (list "published" "draft")) ; supported states
+(defvar tumble-group nil)                      ; uncomment to use a group.
+(defvar tumble-format  "markdown")            ; you can change this to html
+(defvar tumble-api-url "http://www.tumblr.com/api/write")
+(defvar tumble-states (list "published" "draft")) ; supported states
 
 ;; GNUTLS and Mac are not friendly, default TLS to openssl.
 (cond ((equal system-type 'darwin)


### PR DESCRIPTION
There are many byte-compile warnings about this.

```
tumble.el:109:7:Warning: assignment to free variable `tumble-email'
tumble.el:110:7:Warning: assignment to free variable `tumble-password'
tumble.el:111:7:Warning: assignment to free variable `tumble-url'
tumble.el:114:7:Warning: assignment to free variable `tumble-group'
tumble.el:115:7:Warning: assignment to free variable `tumble-format'
tumble.el:116:7:Warning: assignment to free variable `tumble-api-url'
tumble.el:117:7:Warning: assignment to free variable `tumble-states'

In tumble-state-from-partial-string:
tumble.el:126:21:Warning: reference to free variable `tumble-states'

In tumble-login:
tumble.el:139:9:Warning: reference to free variable `tumble-email'
tumble.el:139:26:Warning: assignment to free variable `tumble-email'
tumble.el:140:9:Warning: reference to free variable `tumble-password'
tumble.el:140:29:Warning: assignment to free variable `tumble-password'
tumble.el:141:9:Warning: reference to free variable `tumble-group'
tumble.el:141:26:Warning: assignment to free variable `tumble-group'
tumble.el:142:9:Warning: reference to free variable `tumble-url'
tumble.el:142:24:Warning: assignment to free variable `tumble-url'
```